### PR TITLE
FIX: for require('lspconfig')` "framework" is deprecated

### DIFF
--- a/titus-kickstart/init.lua
+++ b/titus-kickstart/init.lua
@@ -585,7 +585,7 @@ require('lazy').setup({
       for server_name, server_config in pairs(servers) do
         local server = vim.tbl_deep_extend('force', {}, server_config)
         server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-        require('lspconfig')[server_name].setup(server)
+        vim.lsp.config(server_name, server)
       end
     end,
   },
@@ -801,7 +801,6 @@ require('lazy').setup({
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },


### PR DESCRIPTION
refactor: update LSP and Treesitter configuration for Neovim 0.11+

Tested on Ubuntu 24.04.3, Fedora 42, Win 11


- Replace deprecated require('lspconfig') with vim.lsp.config API
  - Updates to nvim-lspconfig v0.11+ compatibility
  - Fixes deprecation warning about lspconfig framework
  - Prepares for nvim-lspconfig v3.0.0 removal of old API

- Remove 'main' directive from nvim-treesitter plugin spec
  - Fixes module loading error with current Treesitter versions
  - Lets lazy.nvim handle module resolution automatically

Resolves errors encountered during plugin initialization.